### PR TITLE
AdddingPowerSupport_&_CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
+arch:
+    - amd64
+    - ppc64le
 language: go
 
 go:
     - 1.1
     - 1.2
     - tip
-
+jobs:
+ exclude:
+    - go: 1.1
+      arch: ppc64le
+    - go: 1.2
+      arch: ppc64le
+      
 install:
     - go get github.com/stretchr/testify
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ jobs:
       arch: ppc64le
     - go: 1.2
       arch: ppc64le
+    - go: 1.1
+      arch: amd64
+    - go: 1.2
+      arch: amd64
+    
       
 install:
     - go get github.com/stretchr/testify


### PR DESCRIPTION
Adding power support ppc64le with Continues Integration/testing so that project stays architecture independent.

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

The build is successful on both arch: amd64/ppc64le, please find the Travis Link below.
https://travis-ci.com/github/santosh653/godbc

Please let me know if you need any further details?

Thank You !!
